### PR TITLE
Fix local variable error

### DIFF
--- a/3DSkit.py
+++ b/3DSkit.py
@@ -45,7 +45,7 @@ def pack_files(filenames, output, compression, format, isbigendian, verbose, opt
 
 def extract_files(filename, isbigendian, format, verbose, opts):
 	endian = '>' if isbigendian else '<'
-	#content = bread(filename)
+	content = None
 	format = unpack.recognize(filename, format)
 	if format not in unpack.SKIP_DECOMPRESSION:
 		content = bread(filename)


### PR DESCRIPTION
If content is defined inside that if statement, line 68 will fail since `content` is scoped to that block. Defining it outside the block allows mutation.

You may want to add additional code to handle the case where `format in unpack.SKIP_DECOMPRESSION`, if that's necessary.